### PR TITLE
Fix deprecation warning in Displaying Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -2426,11 +2426,11 @@ Displaying text
 Use a `Text` object (`PIXI.Text`) to display text on the stage. The constructor
 takes two arguments: the text you want to display and a style object
 that defines the font’s properties. Here's how to display the words
-"Hello Pixi", in white, 32 pixel high sans-serif font.
+"Hello Pixi", in white, 32 pixel high Arial font.
 ```js
 var message = new Text(
   "Hello Pixi!",
-  {font: "32px sans-serif", fill: "white"}
+  {fontFamily: "Arial", fontSize: 32, fill: "white"}
 );
 
 message.position.set(54, 96);


### PR DESCRIPTION
Using the latest Pixi release, a deprecation warning (`text style property 'font' is now deprecated, please use the 'fontFamily','fontSize',fontStyle','fontVariant' and 'fontWeight' properties from now on`)  is emitted when the `font` property is used. Additionally, using a `fontFamily` of `sans-serif` doesn't work, however, `Arial` does.