### PR TITLE
PIXI.Container() called without definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1909,7 +1909,7 @@ tiger.position.set(64, 64);
 Next, create an `animals` container to group them all together like
 this:
 ```js
-let animals = new Container();
+let animals = new PIXI.Container();
 ```
 Then use `addChild` to *add the sprites to the group*.
 ```js


### PR DESCRIPTION
In the example, PIXI.Container(); is not first defined, so needs to be called explicitly.